### PR TITLE
Overhaul of structure - breaking get_delta_stats() into smaller functions

### DIFF
--- a/R/mobr.R
+++ b/R/mobr.R
@@ -429,9 +429,7 @@ samp_ssad = function(comm, groups){
 
 # Auxillary function for get_delta_stats()
 # Overall checks for input values
-# Returns a vector of approved tests
-get_delta_overall_checks = function(comm, type, group_var, env_var, 
-                                    density_stat, tests){
+get_delta_overall_checks = function(comm, type, group_var, env_var, density_stat){
     if (!(type %in% c('continuous', 'discrete')))
         stop('Type has to be discrete or continuous.')
     if (!(density_stat %in% c('mean', 'max', 'min')))
@@ -442,21 +440,48 @@ get_delta_overall_checks = function(comm, type, group_var, env_var,
         if (!(env_var %in% names(comm$env)))
             stop('If env_var is defined, it has to be one of the environmental
                  variables in comm.')
-    
+}
+
+# Auxillary function for get_delta_stats()
+# Checks which tests can be performed
+get_delta_check_tests = function(comm, tests, type, min_plot, group_plots, 
+                                 group_levels, ref_group){
     test_status = sapply(tests, function(x) 
         eval(parse(text = paste('comm$tests$', x, sep = ''))))
     approved_tests = tests[which(test_status == TRUE)]
-    if (any(test_status == FALSE)) {
-        tests_string = paste(tests[which(tests %in% approved_tests)],
-                             collapse=' and ')
-        cat(paste('Based upon the attributes of the community object only the following tests will be performed:',
-                  tests_string))
+    # Additional check for aggregation analysis
+    # NOTE: may not be necessary since we are also looking at within-plot aggregation 
+    if ('agg' %in% approved_tests){
+        if (!is.null(min_plots)){
+            groups_keep = as.character(group_plots[which(group_plots$Freq >= 
+                                                             min_plots), 1])
+        } else {groups_keep = group_levels}
+        agg_keep = FALSE
+        if (type == 'discrete'){
+            if (length(groups_keep) == 1){
+                warning('Test for aggregation cannot be conducted with only one 
+                        group left.')
+            } else if (!(ref_group %in% groups_keep)){
+                warning('Test for aggregation cannot be conducted because the 
+                        reference group has been dropped.')
+            } else {agg_keep = TRUE}
+        } else if (length(groups_keep) < 3){
+            warning('Test for aggregation cannot be conducted in the continuous
+                    case with less than three groups left.')
+        } else {agg_keep = TRUE}
+        
+        if (agg_keep == F)
+            approved_tests = approved_tests[approved_tests != 'agg']
+    }
+    
+    if (length(approved_tests) < length(tests)) {
+        tests_string = paste(approved_tests, collapse=' and ')
+        cat(paste('Based upon the attributes of the community object only the 
+                  following tests will be performed:', tests_string))
     }
     return(approved_tests)
 }
 
-# Auxillary function for get_delta_stats()
-# Returns 
 # Auxillary function for get_delta_stats()
 # Perform checks when type is "discrete"
 get_delta_discrete_checks = function(ref_group, group_levels, group_data, env_var){
@@ -790,11 +815,11 @@ effect_N_discrete = function(out, comm, group_levels, ref_group, groups,
 get_delta_stats = function(comm, group_var, env_var = NULL, ref_group = NULL, 
                            tests = c('SAD', 'N', 'agg'),
                            type='discrete', inds = NULL, log_scale = FALSE,
-                           min_plot = NULL, density_stat ='mean',
+                           min_plots = NULL, density_stat ='mean',
                            corr='spearman', nperm=1000) {
     
-    approved_tests = get_delta_overall_checks(comm, type, group_var, env_var, 
-                                              density_stat, tests)
+    get_delta_overall_checks(comm, type, group_var, env_var, density_stat)
+    
     S = ncol(comm$comm)
     plot_abd = rowSums(comm$comm)
     group_data = comm$env[, group_var]
@@ -814,6 +839,8 @@ get_delta_stats = function(comm, group_var, env_var = NULL, ref_group = NULL,
     group_sad = group_sad[, -1]
     ind_sample_size = get_delta_ind_sample(group_sad, inds, log_scale)
     plot_dens = get_plot_dens(comm$comm, density_stat)
+    approved_tests = get_delta_check_tests(comm, tests, type, min_plots, 
+                                           group_plots, group_levels, ref_group)
     
     out = list()  
     out$type = type
@@ -823,7 +850,8 @@ get_delta_stats = function(comm, group_var, env_var = NULL, ref_group = NULL,
     out$indiv_rare = cbind(ind_sample_size, ind_rare)
     names(out$indiv_rare) = c('sample', group_levels)
     out = get_sample_curves(out, comm, group_levels, approved_tests)
-        
+    
+    
     if (type == 'continuous'){
         get_delta_continuous_checks(corr, group_levels, env_levels)
         if ('SAD' %in% approved_tests)

--- a/R/mobr.R
+++ b/R/mobr.R
@@ -528,17 +528,16 @@ get_plot_dens = function(site_sp_mat, density_stat){
 # Auxillary function for get_delta_stats()
 # Obtain the swap curve and/or spatial curve for each group if asked
 # Directly add attributes to the input "out"
-get_sample_curves = function(out, comm, group_levels, approved_tests){
+get_sample_curves = function(comm, group_levels, approved_tests){
     if ('N' %in% approved_tests | 'agg' %in% approved_tests){
-        out$sample_rare = data.frame(matrix(0, nrow = 0, ncol = 4), 
-                                     stringsAsFactors = F)
+        sample_rare = data.frame(matrix(0, nrow = 0, ncol = 4), 
+                                 stringsAsFactors = F)
         for (level in group_levels){
             comm_level = comm$comm[as.character(group_data) == level, ]
             nplots = nrow(comm_level)
             level_dens = sum(comm_level) / nplots
             samp_effort = round((1:nplots) * level_dens)
             impl_S = rarefaction(comm_level, 'indiv', samp_effort)
-            #impl_S = avg_perm_rare(comm_level, 'noagg', nperm = 100)
             sample_rare_level = data.frame(cbind(rep(level, length(impl_S)), 
                                                  seq(length(impl_S)), impl_S))
             if ('agg' %in% approved_tests){
@@ -546,14 +545,14 @@ get_sample_curves = function(out, comm, group_levels, approved_tests){
                 expl_S = rarefy_sample_explicit(comm_level, xy_level)
                 sample_rare_level = cbind(sample_rare_level, expl_S)
             }
-            out$sample_rare = rbind(out$sample_rare, sample_rare_level)
+            sample_rare = rbind(sample_rare, sample_rare_level)
         }
-        names(out$sample_rare)[1:3] = c('group', 'sample_plot', 'impl_S')
+        names(sample_rare)[1:3] = c('group', 'sample_plot', 'impl_S')
         if ('agg' %in% approved_tests)
-            names(out$sample_rare)[4] = 'expl_S'
+            names(sample_rare)[4] = 'expl_S'
     }
-    out$sample_rare = df_factor_to_numeric(out$sample_rare, 2:ncol(out$sample_rare))
-    return(out)
+    sample_rare = df_factor_to_numeric(sample_rare, 2:ncol(sample_rare))
+    return(sample_rare)
 }
 
 # Auxillary function for get_delta_stats()
@@ -834,7 +833,7 @@ get_delta_stats = function(comm, group_var, env_var = NULL, ref_group = NULL,
         rarefaction(x, 'indiv', ind_sample_size)))
     out$indiv_rare = cbind(ind_sample_size, ind_rare)
     names(out$indiv_rare) = c('sample', group_levels)
-    out = get_sample_curves(out, comm, group_levels, approved_tests)
+    out$sample_rare = get_sample_curves(comm, group_levels, approved_tests)
     
     
     if (type == 'continuous'){

--- a/R/mobr.R
+++ b/R/mobr.R
@@ -257,8 +257,7 @@ deltaS_N = function(comm_group, ref_dens, inds){
   # using the ref_density (i.e., not the observed density)
   rescaled_effort = round(1:nplots * ref_dens)
   if (max(rescaled_effort) < max(inds))
-    warning('Extrapolating the rarefaction curve because the number of rescaled
-            individuals is smaller than the inds argument')
+    warning('Extrapolating the rarefaction curve because the number of rescaled individuals is smaller than the inds argument')
   interp_S_samp = pchip(c(1, rescaled_effort), c(1, S_samp), inds)
   S_indiv = rarefaction(comm_group, 'indiv', inds)
   deltaS = interp_S_samp - S_indiv
@@ -473,8 +472,7 @@ get_delta_discrete_checks = function(ref_group, group_levels, group_data, env_va
     if (!is.null(env_var))
         warning('Environmental variable is not used in the discrete analysis.')
     if (!('factor' %in% class(group_data))) 
-        warning('Grouping variable is not a factor. A group will be defined for
-                each unique value.')
+        warning('Grouping variable is not a factor. A group will be defined for each unique value.')
 }
 
 # Auxillary function for get_delta_stats()
@@ -485,8 +483,7 @@ get_delta_continuous_checks = function(corr, group_levels, env_levels){
     if ('factor' %in% class(env_levels)) {
         env_vals = data.frame(groups = group_levels, 
                               values = as.numeric(env_levels)[match(group_levels, env_levels)])
-        warning('Variable of interest is a factor but will be treated as a continous 
-                variable for the analysis with the above values')
+        warning('Variable of interest is a factor but will be treated as a continous variable for the analysis with the above values')
         print(env_vals)
     } 
 }

--- a/R/mobr.R
+++ b/R/mobr.R
@@ -552,6 +552,7 @@ get_sample_curves = function(out, comm, group_levels, approved_tests){
         if ('agg' %in% approved_tests)
             names(out$sample_rare)[4] = 'expl_S'
     }
+    out$sample_rare = df_factor_to_numeric(out$sample_rare, 2:ncol(out$sample_rare))
     return(out)
 }
 
@@ -589,6 +590,7 @@ effect_SAD_continuous = function(out, group_sad, env_levels, nperm){
                                             t(ind_r_null_CI)))
     names(out$continuous$indiv) = c('effort_ind', 'r_emp', 'r_null_low', 
                                     'r_null_median', 'r_null_high')
+    out$continuous$indiv = df_factor_to_numeric(out$continuous$indiv)
     return(out)
 }
 
@@ -628,6 +630,8 @@ effect_SAD_discrete = function(out, group_sad, group_levels, ref_group, nperm){
         out$discrete$indiv = rbind(out$discrete$indiv, ind_level)
     }
     close(pb)
+    out$discrete$indiv = df_factor_to_numeric(out$discrete$indiv, 
+                                              2:ncol(out$discrete$indiv))
     names(out$discrete$indiv) = c('group', 'effort_ind', 'deltaS_emp',
                                   'deltaS_null_low', 'deltaS_null_median',
                                   'deltaS_null_high')
@@ -676,7 +680,9 @@ effect_N_continuous = function(out, comm, S, group_levels, env_levels, group_dat
     N_r_null_CI = apply(null_N_r_mat, 2, function(x) 
         quantile(x, c(0.025, 0.5, 0.975), na.rm = T))
     out$continuous$N = data.frame(cbind(effect_N_by_group[, 1], r_emp, t(N_r_null_CI)))
-    names(out$continuous$N) = c('effort_ind', 'r_emp', 'r_null_low', 'r_null_median', 'r_null_high')
+    out$continuous$N = df_factor_to_numeric(out$continuous$N)
+    names(out$continuous$N) = c('effort_ind', 'r_emp', 'r_null_low', 
+                                'r_null_median', 'r_null_high')
     return(out)
 }
 
@@ -715,11 +721,11 @@ effect_N_discrete = function(out, comm, group_levels, ref_group, groups,
         out$discrete$N = rbind(out$discrete$N, N_level)
     }
     close(pb)
+    out$discrete$N = df_factor_to_numeric(out$discrete$N, 2:ncol(out$discrete$N))
     names(out$discrete$N) = c('group', 'effort_sample', 'ddeltaS_emp', 'ddeltaS_null_low', 
                               'ddeltaS_null_median', 'ddeltaS_null_high')
     return(out)
 }
-
 
 #' Conduct the MOBR tests on drivers of biodiversity across scales.
 #' 

--- a/R/mobr.R
+++ b/R/mobr.R
@@ -427,6 +427,16 @@ samp_ssad = function(comm, groups){
   return(comm_out)
 }
 
+# Convert specified columns of a dataframe from factors to numeric
+df_factor_to_numeric = function(dataframe, cols = NULL){
+    if (is.null(cols)) cols = 1:ncol(dataframe)
+    for (col in cols){
+        if ('factor' %in% class(dataframe[, col]))
+            dataframe[, col] = as.numeric(levels(dataframe[, col]))[dataframe[, col]]
+    }
+    return(dataframe)
+}
+
 # Auxillary function for get_delta_stats()
 # Overall checks for input values
 get_delta_overall_checks = function(comm, type, group_var, env_var, 


### PR DESCRIPTION
The general idea of this PR is to pull out individual elements from the monstrous function `get_delta_stats()` and rewrite them into separate functions, so that hopefully our code is both easier to understand and easier to debug (ie an individual piece can be modified without affecting others).  Tests for SAD & N are done; test for aggregation is currently commented out b/c we haven't had a solution yet. 

@dmcglinn let me know if you'd prefer to have one of our earlier (unsuccessful) attempts for aggregation as a place holder. Also I think I've fixed a bug in your function `permute_comm()` when `swap == 'swapN'`; could you make sure that was correct? 