### PR TITLE
Attempt to resolve warnings in effect_N_discrete

### DIFF
--- a/R/mobr.R
+++ b/R/mobr.R
@@ -614,10 +614,12 @@ effect_N_discrete = function(mob_in, group_levels, ref_group, groups,
         for (i in 1:nperm){
             # swap plot abu between group 1 and each other group
             comm_perm = permute_comm(comm_levels, 'swapN', plot_levels)  
+            min_N = min(sum(comm_perm[plot_levels == as.character(ref_group), ]), 
+                        sum(comm_perm[plot_levels == level, ]))
             N_eff_perm = sapply(c(as.character(ref_group), level), function(x) 
                 deltaS_N(comm_perm[plot_levels == x, ], plot_dens_level, 
-                         ind_sample_size)$deltaS)
-            null_N_deltaS_mat[i, ] = N_eff_perm[ , 2] - N_eff_perm[ , 1]
+                         ind_sample_size[ind_sample_size <= min_N])$deltaS)
+            null_N_deltaS_mat[i, ] = (N_eff_perm[ , 2] - N_eff_perm[ , 1])[1:ncol(null_N_deltaS_mat)]
             setTxtProgressBar(pb, k)
             k = k + 1
         }

--- a/R/mobr.R
+++ b/R/mobr.R
@@ -240,9 +240,8 @@ deltaS_N = function(comm, ref_dens, inds){
     # rescale and interpolate this plot based S to individual based 
     # using the ref_density (i.e., not the observed density)
     rescaled_effort = round(1:nplots * ref_dens)
-    if (max(rescaled_effort) < max(inds))
-        warning('Extrapolating the rarefaction curve because the number of rescaled individuals is smaller than the inds argument')
-    interp_S_samp = pchip(c(1, rescaled_effort), c(1, S_samp), inds)
+    # No extrapolation of the rescaled rarefaction curve, only interpolation
+    interp_S_samp = pchip(c(1, rescaled_effort), c(1, S_samp), inds[inds <= max(rescaled_effort)])[1:length(inds)]
     S_indiv = rarefaction(comm, 'indiv', inds)
     deltaS = interp_S_samp - S_indiv
     out = data.frame(inds = inds, deltaS = deltaS)

--- a/R/mobr.R
+++ b/R/mobr.R
@@ -241,7 +241,9 @@ deltaS_N = function(comm, ref_dens, inds){
     # using the ref_density (i.e., not the observed density)
     rescaled_effort = round(1:nplots * ref_dens)
     # No extrapolation of the rescaled rarefaction curve, only interpolation
-    interp_S_samp = pchip(c(1, rescaled_effort), c(1, S_samp), inds[inds <= max(rescaled_effort)])[1:length(inds)]
+    interp_S_samp = pchip(c(1, rescaled_effort), c(1, S_samp), inds[inds <= max(rescaled_effort)])
+    # Ensure that interp_S_samp has the right length (filled with NA's if needed)
+    interp_S_samp = interp_S_samp[1:length(inds)]
     S_indiv = rarefaction(comm, 'indiv', inds)
     deltaS = interp_S_samp - S_indiv
     out = data.frame(inds = inds, deltaS = deltaS)
@@ -572,6 +574,7 @@ effect_N_continuous = function(mob_in, S, group_levels, env_levels, group_data,
             comm_level_perm = comm_perm[which(as.character(group_data) == level_perm), ]
             group_effect_N_perm = deltaS_N(comm_level_perm, plot_dens, 
                                            ind_sample_size[ind_sample_size <= sum(comm_level_perm)])
+            # Ensure the column has the right length (filled with NA's if needed)
             effect_N_perm[, j] = group_effect_N_perm$deltaS[1:nrow(effect_N_perm)]
         }
         effect_N_perm = effect_N_perm[complete.cases(effect_N_perm), ]
@@ -618,7 +621,9 @@ effect_N_discrete = function(mob_in, group_levels, ref_group, groups,
             N_eff_perm = sapply(c(as.character(ref_group), level), function(x) 
                 deltaS_N(comm_perm[plot_levels == x, ], plot_dens_level, 
                          ind_sample_size[ind_sample_size <= min_N])$deltaS)
-            null_N_deltaS_mat[i, ] = (N_eff_perm[ , 2] - N_eff_perm[ , 1])[1:ncol(null_N_deltaS_mat)]
+            ddeltaS_perm = N_eff_perm[ , 2] - N_eff_perm[ , 1]
+            # Ensure the row has the right length (filled with NA's if needed)
+            null_N_deltaS_mat[i, ] = ddeltaS_perm[1:ncol(null_N_deltaS_mat)]
             setTxtProgressBar(pb, k)
             k = k + 1
         }

--- a/R/mobr.R
+++ b/R/mobr.R
@@ -572,8 +572,8 @@ effect_N_continuous = function(mob_in, S, group_levels, env_levels, group_data,
             level_perm = group_levels[j]
             comm_level_perm = comm_perm[which(as.character(group_data) == level_perm), ]
             group_effect_N_perm = deltaS_N(comm_level_perm, plot_dens, 
-                                           ind_sample_size)
-            effect_N_perm[, j] = group_effect_N_perm$deltaS
+                                           ind_sample_size[ind_sample_size <= sum(comm_level_perm)])
+            effect_N_perm[, j] = group_effect_N_perm$deltaS[1:nrow(effect_N_perm)]
         }
         effect_N_perm = effect_N_perm[complete.cases(effect_N_perm), ]
         # If the output is not long enough, fill it with NA's


### PR DESCRIPTION
This issue is described in #21 .

There were two warnings: 
 - warning in `rarefaction` occurred when the summed N of two treatments were close. By swapping plot-level n among plots, the treatment with smaller N to start with would sometimes end up with even lower N, and as a result the individual-based curve couldn't be built all the way to the previous ending point.
 - warning in `deltaS_N` occurred when the treatments differed considerably in average density. The rarefaction curve of the higher-density-treatment could be shrunk below the ending point by the rescaling in `deltaS_N`. 

In both cases I implemented the fix to fill the dataframe with `NA's` at the bottom, instead of rarefying beyond total `N` or extrapolating the rarefaction curve beyond its ending point. 