### PR TITLE
Add option to calculate distance based on latitude and longitude.

### DIFF
--- a/R/mobr.R
+++ b/R/mobr.R
@@ -693,8 +693,8 @@ effect_N_continuous = function(mob_in, S, group_levels, env_levels, group_data,
 #' Auxillary function for get_delta_stats()
 #' Effect of N when type is "discrete" 
 #' @keywords internal
-effect_N_discrete = function(mob_in, group_levels, ref_group, groups, 
-                             density_stat, ind_sample_size, nperm){
+effect_N_discrete = function(out, mob_in, group_levels, ref_group, groups, 
+                             density_stat, ind_sample_size, nperm, overall_p){
     out_N = NULL
     if (overall_p)
         overallp_N = data.frame(matrix(0, nrow = 0, ncol = 2), 
@@ -735,13 +735,15 @@ effect_N_discrete = function(mob_in, group_levels, ref_group, groups,
         if (overall_p){
             p_level = get_overall_p(ind_sample_size, ddeltaS_level, 
                                     null_N_deltaS_mat)
+            out$overall_p$N[out$overall_p$group == level] = p_level
         }
     }
     close(pb)
     out_N = df_factor_to_numeric(out_N, 2:ncol(out_N))
     names(out_N) = c('group', 'effort_sample', 'ddeltaS_emp', 'ddeltaS_null_low', 
                      'ddeltaS_null_median', 'ddeltaS_null_high')
-    return(out_N)
+    out$N = out_N
+    return(out)
 }
 
 #' Auxillary function for get_delta_stats()
@@ -953,7 +955,7 @@ get_delta_stats = function(mob_in, group_var, env_var = NULL, ref_group = NULL,
         if ('SAD' %in% approved_tests)
             out = effect_SAD_continuous(out, group_sad, env_levels, corr, nperm)
         if ('N' %in% approved_tests)
-            out$N = effect_N_continuous(mob_in, S, group_levels, env_levels, 
+            out = effect_N_continuous(out, mob_in, S, group_levels, env_levels, 
                                         group_data, plot_dens, plot_abd, 
                                         ind_sample_size, corr, nperm)
         if ('agg' %in% approved_tests)
@@ -972,10 +974,10 @@ reflect significance at any particular scale. Be careful in interpretation.')
         }
         if ('SAD' %in% approved_tests)
             out = effect_SAD_discrete(out, group_sad, group_levels, ref_group,
-                                      nperm)
+                                      nperm, overall_p)
         if ('N' %in% approved_tests)
-            out$N = effect_N_discrete(mob_in, group_levels, ref_group, groups,
-                                      density_stat,ind_sample_size, nperm)
+            out = effect_N_discrete(out, mob_in, group_levels, ref_group, groups,
+                                      density_stat,ind_sample_size, nperm, overall_p)
         if ('agg' %in% approved_tests)
             out$agg = effect_agg_discrete(mob_in, out$sample_rare, ref_group, 
                                           group_plots, group_data, group_levels,

--- a/R/mobr_boxplots.R
+++ b/R/mobr_boxplots.R
@@ -74,6 +74,13 @@ These are removed for the calculation of rarefied richness."))
    S_rare_sample[!plots_low_n] = apply(mob_in$comm[!plots_low_n,], MARGIN = 1,
                                        FUN = rarefaction, method = "indiv",
                                        effort = N_min_sample)
+   # If all plots within a treatment are removed, skip analysis on S_rare_sample
+   if (length(unique(group_id[!is.na(S_rare_sample)])) < 2) {
+       keep_rare_sample = FALSE
+       warning("All plots from one or more treatments have low abundances, analysis for plot-level rarefied richness is skipped.")
+   } else{
+       keep_rare_sample = TRUE
+   }
    
    # Probability of Interspecific Encounter
    plots_n0 = N_sample == 0
@@ -134,7 +141,8 @@ These are removed for the calculation of rarefied richness."))
    # permutation test for differences among samples
    F_obs <- data.frame(S       = anova(lm(S_sample ~ group_id))$F[1],
                        N       = anova(lm(N_sample ~ group_id))$F[1],
-                       S_rare  = anova(lm(S_rare_sample ~ group_id))$F[1],
+                       S_rare = ifelse(!keep_rare_sample, NA, 
+                                       anova(lm(S_rare_sample ~ group_id))$F[1]), 
                        PIE     = anova(lm(PIE_sample ~ group_id))$F[1],
                        ENS_PIE = anova(lm(ENS_PIE_sample ~ group_id))$F[1],
                        S_asymp = anova(lm(S_asymp_sample ~ group_id))$F[1],
@@ -154,7 +162,8 @@ These are removed for the calculation of rarefied richness."))
       group_id_rand     = sample(group_id)
       F_rand$S[i]       = anova(lm(S_sample ~ group_id_rand))$F[1]
       F_rand$N[i]       = anova(lm(N_sample ~ group_id_rand))$F[1]
-      F_rand$S_rare[i]  = anova(lm(S_rare_sample ~ group_id_rand))$F[1]
+      F_rand$S_rare[i]  = ifelse(!keep_rare_sample, NA, 
+                                 anova(lm(S_rare_sample ~ group_id_rand))$F[1])
       F_rand$PIE[i]     = anova(lm(PIE_sample ~ group_id_rand))$F[1]
       F_rand$ENS_PIE[i] = anova(lm(ENS_PIE_sample ~ group_id_rand))$F[1]
       F_rand$S_asymp[i] = anova(lm(S_asymp_sample ~ group_id_rand))$F[1]
@@ -163,7 +172,8 @@ These are removed for the calculation of rarefied richness."))
    
    p_S       = sum(F_obs$S       <= F_rand$S) / nperm
    p_N       = sum(F_obs$N       <= F_rand$N) / nperm
-   p_S_rare  = sum(F_obs$S_rare  <= F_rand$S_rare) / nperm
+   p_S_rare  = ifelse(!keep_rare_sample, NA, 
+                      sum(F_obs$S_rare  <= F_rand$S_rare) / nperm)
    p_PIE     = sum(F_obs$PIE     <= F_rand$PIE) / nperm
    p_ENS_PIE = sum(F_obs$ENS_PIE <= F_rand$ENS_PIE) / nperm
    p_S_asymp = sum(F_obs$S_asymp <= F_rand$S_asymp) / nperm

--- a/R/mobr_boxplots.R
+++ b/R/mobr_boxplots.R
@@ -74,13 +74,6 @@ These are removed for the calculation of rarefied richness."))
    S_rare_sample[!plots_low_n] = apply(mob_in$comm[!plots_low_n,], MARGIN = 1,
                                        FUN = rarefaction, method = "indiv",
                                        effort = N_min_sample)
-   # If all plots within a treatment are removed, skip analysis on S_rare_sample
-   if (length(unique(group_id[!is.na(S_rare_sample)])) < 2) {
-       keep_rare_sample = FALSE
-       warning("All plots from one or more treatments have low abundances, analysis for plot-level rarefied richness is skipped.")
-   } else{
-       keep_rare_sample = TRUE
-   }
    
    # Probability of Interspecific Encounter
    plots_n0 = N_sample == 0
@@ -141,8 +134,7 @@ These are removed for the calculation of rarefied richness."))
    # permutation test for differences among samples
    F_obs <- data.frame(S       = anova(lm(S_sample ~ group_id))$F[1],
                        N       = anova(lm(N_sample ~ group_id))$F[1],
-                       S_rare = ifelse(!keep_rare_sample, NA, 
-                                       anova(lm(S_rare_sample ~ group_id))$F[1]), 
+                       S_rare  = anova(lm(S_rare_sample ~ group_id))$F[1],
                        PIE     = anova(lm(PIE_sample ~ group_id))$F[1],
                        ENS_PIE = anova(lm(ENS_PIE_sample ~ group_id))$F[1],
                        S_asymp = anova(lm(S_asymp_sample ~ group_id))$F[1],
@@ -162,8 +154,7 @@ These are removed for the calculation of rarefied richness."))
       group_id_rand     = sample(group_id)
       F_rand$S[i]       = anova(lm(S_sample ~ group_id_rand))$F[1]
       F_rand$N[i]       = anova(lm(N_sample ~ group_id_rand))$F[1]
-      F_rand$S_rare[i]  = ifelse(!keep_rare_sample, NA, 
-                                 anova(lm(S_rare_sample ~ group_id_rand))$F[1])
+      F_rand$S_rare[i]  = anova(lm(S_rare_sample ~ group_id_rand))$F[1]
       F_rand$PIE[i]     = anova(lm(PIE_sample ~ group_id_rand))$F[1]
       F_rand$ENS_PIE[i] = anova(lm(ENS_PIE_sample ~ group_id_rand))$F[1]
       F_rand$S_asymp[i] = anova(lm(S_asymp_sample ~ group_id_rand))$F[1]
@@ -172,8 +163,7 @@ These are removed for the calculation of rarefied richness."))
    
    p_S       = sum(F_obs$S       <= F_rand$S) / nperm
    p_N       = sum(F_obs$N       <= F_rand$N) / nperm
-   p_S_rare  = ifelse(!keep_rare_sample, NA, 
-                      sum(F_obs$S_rare  <= F_rand$S_rare) / nperm)
+   p_S_rare  = sum(F_obs$S_rare  <= F_rand$S_rare) / nperm
    p_PIE     = sum(F_obs$PIE     <= F_rand$PIE) / nperm
    p_ENS_PIE = sum(F_obs$ENS_PIE <= F_rand$ENS_PIE) / nperm
    p_S_asymp = sum(F_obs$S_asymp <= F_rand$S_asymp) / nperm


### PR DESCRIPTION
I tried to disrupt the old code as little as possible and as a result the naming etc may not be totally intuitive. A new attribute `latlong` is added to the `mob_in` object. If it is `TRUE`, the x coords are interpreted to be the longitudes, and the y coords the latitudes. Both columns have to be specified otherwise `make_mob_in` would throw an error message. The distance matrix between plots is then calculated using the Haversine formula, which accounts for small distance distortions but still assumes that the earth is a perfect sphere. 