### PR TITLE
Fix bug reported by Shane - blue/red could be mixed for rarefaction curves in plotting

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -12,9 +12,11 @@ Description: This package is designed to help measure biodiversity and its
 Depends:
     R (>= 3.0.2),
     Jade,
-    rgl,
+    pracma,
     scales,
     vegan
+Suggests:
+    rgl
 Remotes:
     JohnsonHsieh/Jade,
 License: MIT

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -11,14 +11,12 @@ Description: This package is designed to help measure biodiversity and its
     changes across scales.
 Depends:
     R (>= 3.0.2),
-    pracma,
     Jade,
     rgl,
     scales,
     vegan
 Remotes:
     JohnsonHsieh/Jade,
-    AnneChao/SpadeR
 License: MIT
 LazyData: true
 RoxygenNote: 5.0.1

--- a/R/mobr.R
+++ b/R/mobr.R
@@ -1231,7 +1231,9 @@ plot.mob_out = function(mob_out, trt_group, ref_group, same_scale=FALSE,
     tests = mob_out$tests
     if (type == 'continuous')
         stop("Currently this plot only works for mob_out object with type discrete.")
-    cols = c('red', 'blue')
+    cols = list()
+    cols$trt = 'red'
+    cols$ref = 'blue'
     deltaS_col = 'turquoise'
     ddeltaS_col = 'magenta'
     if (is.null(par_args)) {
@@ -1271,21 +1273,15 @@ plot.mob_out = function(mob_out, trt_group, ref_group, same_scale=FALSE,
         if ('SAD' %in% mob_out$tests) {
             if (!same_scale)
                 ylim_rare = range(mob_out$indiv_rare[, -1])
-            for (icol in 2:ncol(mob_out$indiv_rare)){
-                if (icol == 2)
-                    plot(mob_out$indiv_rare$sample, mob_out$indiv_rare[, icol],
-                         lwd = 2, type = 'l', col = cols[icol - 1], 
-                         xlab = 'Number of individuals', ylab = 'Richness (S)',
-                         main = 'Individual', 
-                         xlim = c(xmin, max(mob_out$indiv_rare$sample)),
-                         ylim = ylim_rare,
-                         cex.axis = 1.5, cex.lab = 1.5, log=plot_log)
-               else
-                    lines(mob_out$indiv_rare$sample, 
-                          mob_out$indiv_rare[, icol], lwd = 2,
-                          col = cols[icol - 1])
-            }     
-            legend('topleft', as.character(groups), col=cols, lty=1, lwd=2, bty='n')
+            plot(mob_out$indiv_rare$sample, mob_out$indiv_rare[, trt_group], 
+                 lwd = 2, type = 'l', col = cols$trt, xlab = 'Number of individuals', 
+                 ylab = 'Richness (S)', main = 'Individual', 
+                 xlim = c(xmin, max(mob_out$indiv_rare$sample)), ylim = ylim_rare, 
+                 cex.axis = 1.5, cex.lab = 1.5, log=plot_log)
+            lines(mob_out$indiv_rare$sample, mob_out$indiv_rare[, ref_group], 
+                  lwd = 2, col = cols$ref)
+            legend('topleft', as.character(groups), col=as.character(unlist(cols)), 
+                   lty=1, lwd=2, bty='n')
         }
         if ('N' %in% mob_out$tests) {
             if (!same_scale)
@@ -1296,14 +1292,14 @@ plot.mob_out = function(mob_out, trt_group, ref_group, same_scale=FALSE,
                 if (i == 1)
                     plot(dat_group$sample_plot, dat_group$impl_S,
                          lwd = 2, type = 'l', xlab = 'Number of plots',
-                         ylab = 'Richness (S)', col = cols[i], 
+                         ylab = 'Richness (S)', col = cols$trt, 
                          xlim = c(xmin, max(dat_group$sample_plot)),
                          ylim = ylim_rare,
                          main = 'Sample', cex.axis = 1.5, cex.lab = 1.5,
                          log=plot_log)
                else
                    lines(dat_group$sample_plot, dat_group$impl_S,
-                         lwd = 2, col = cols[i])
+                         lwd = 2, col = cols$ref)
             }
         }
         if ('agg' %in% mob_out$tests) {
@@ -1315,14 +1311,14 @@ plot.mob_out = function(mob_out, trt_group, ref_group, same_scale=FALSE,
                 if (i == 1)
                     plot(dat_group$sample_plot, dat_group$expl_S, lwd = 2,
                          type = 'l', xlab = 'Number of plots',
-                         ylab = 'Richness (S)', col = cols[i],
+                         ylab = 'Richness (S)', col = cols$trt,
                          xlim = c(xmin, max(dat_group$sample_plot)),
                          ylim = ylim_rare,
                          main = 'Spatial', cex.axis = 1.5, cex.lab = 1.5,
                          log=plot_log)
                 else
                     lines(dat_group$sample_plot, dat_group$expl_S,
-                          lwd = 2, col = cols[i])
+                          lwd = 2, col = cols$ref)
             }
         }
     }    

--- a/R/mobr_boxplots.R
+++ b/R/mobr_boxplots.R
@@ -72,13 +72,6 @@ get_mob_stats = function(mob_in, group_var, n_min = 10, nperm = 1000) {
    S_rare_sample[!plots_low_n] = apply(mob_in$comm[!plots_low_n,], MARGIN = 1,
                                        FUN = rarefaction, method = "indiv",
                                        effort = N_min_sample)
-   # If all plots within a treatment are removed, skip analysis on S_rare_sample
-   if (length(unique(group_id[!is.na(S_rare_sample)])) < 2) {
-       keep_rare_sample = FALSE
-       warning("All plots from one or more treatments have low abundances, analysis for plot-level rarefied richness is skipped.")
-   } else {
-       keep_rare_sample = TRUE
-   }
    
    # Probability of Interspecific Encounter
    plots_n0 = N_sample == 0
@@ -167,8 +160,7 @@ These are removed for the calculation of rarefied richness."))
    # permutation test for differences among samples
    F_obs <- data.frame(S       = anova(lm(S_sample ~ group_id))$F[1],
                        N       = anova(lm(N_sample ~ group_id))$F[1],
-                       S_rare  = ifelse(!keep_rare_sample, NA, 
-                                        anova(lm(S_rare_sample ~ group_id))$F[1]),
+                       S_rare  = anova(lm(S_rare_sample ~ group_id))$F[1],
                        PIE     = anova(lm(PIE_sample ~ group_id))$F[1],
                        ENS_PIE = anova(lm(ENS_PIE_sample ~ group_id))$F[1],
                        S_asymp = anova(lm(S_asymp_sample ~ group_id))$F[1],
@@ -188,8 +180,7 @@ These are removed for the calculation of rarefied richness."))
       group_id_rand     = sample(group_id)
       F_rand$S[i]       = anova(lm(S_sample ~ group_id_rand))$F[1]
       F_rand$N[i]       = anova(lm(N_sample ~ group_id_rand))$F[1]
-      F_rand$S_rare[i]  = ifelse(!keep_rare_sample, NA, 
-                                 anova(lm(S_rare_sample ~ group_id_rand))$F[1])
+      F_rand$S_rare[i]  = anova(lm(S_rare_sample ~ group_id_rand))$F[1]
       F_rand$PIE[i]     = anova(lm(PIE_sample ~ group_id_rand))$F[1]
       F_rand$ENS_PIE[i] = anova(lm(ENS_PIE_sample ~ group_id_rand))$F[1]
       F_rand$S_asymp[i] = anova(lm(S_asymp_sample ~ group_id_rand))$F[1]
@@ -198,8 +189,7 @@ These are removed for the calculation of rarefied richness."))
    
    p_S       = sum(F_obs$S       <= F_rand$S) / nperm
    p_N       = sum(F_obs$N       <= F_rand$N) / nperm
-   p_S_rare  = ifelse(!keep_rare_sample, NA, 
-                      sum(F_obs$S_rare  <= F_rand$S_rare) / nperm)
+   p_S_rare  = sum(F_obs$S_rare  <= F_rand$S_rare) / nperm
    p_PIE     = sum(F_obs$PIE     <= F_rand$PIE) / nperm
    p_ENS_PIE = sum(F_obs$ENS_PIE <= F_rand$ENS_PIE) / nperm
    p_S_asymp = sum(F_obs$S_asymp <= F_rand$S_asymp) / nperm

--- a/R/mobr_boxplots.R
+++ b/R/mobr_boxplots.R
@@ -72,6 +72,13 @@ get_mob_stats = function(mob_in, group_var, n_min = 10, nperm = 1000) {
    S_rare_sample[!plots_low_n] = apply(mob_in$comm[!plots_low_n,], MARGIN = 1,
                                        FUN = rarefaction, method = "indiv",
                                        effort = N_min_sample)
+   # If all plots within a treatment are removed, skip analysis on S_rare_sample
+   if (length(unique(group_id[!is.na(S_rare_sample)])) < 2) {
+       keep_rare_sample = FALSE
+       warning("All plots from one or more treatments have low abundances, analysis for plot-level rarefied richness is skipped.")
+   } else {
+       keep_rare_sample = TRUE
+   }
    
    # Probability of Interspecific Encounter
    plots_n0 = N_sample == 0
@@ -160,7 +167,8 @@ These are removed for the calculation of rarefied richness."))
    # permutation test for differences among samples
    F_obs <- data.frame(S       = anova(lm(S_sample ~ group_id))$F[1],
                        N       = anova(lm(N_sample ~ group_id))$F[1],
-                       S_rare  = anova(lm(S_rare_sample ~ group_id))$F[1],
+                       S_rare  = ifelse(!keep_rare_sample, NA, 
+                                        anova(lm(S_rare_sample ~ group_id))$F[1]),
                        PIE     = anova(lm(PIE_sample ~ group_id))$F[1],
                        ENS_PIE = anova(lm(ENS_PIE_sample ~ group_id))$F[1],
                        S_asymp = anova(lm(S_asymp_sample ~ group_id))$F[1],
@@ -180,7 +188,8 @@ These are removed for the calculation of rarefied richness."))
       group_id_rand     = sample(group_id)
       F_rand$S[i]       = anova(lm(S_sample ~ group_id_rand))$F[1]
       F_rand$N[i]       = anova(lm(N_sample ~ group_id_rand))$F[1]
-      F_rand$S_rare[i]  = anova(lm(S_rare_sample ~ group_id_rand))$F[1]
+      F_rand$S_rare[i]  = ifelse(!keep_rare_sample, NA, 
+                                 anova(lm(S_rare_sample ~ group_id_rand))$F[1])
       F_rand$PIE[i]     = anova(lm(PIE_sample ~ group_id_rand))$F[1]
       F_rand$ENS_PIE[i] = anova(lm(ENS_PIE_sample ~ group_id_rand))$F[1]
       F_rand$S_asymp[i] = anova(lm(S_asymp_sample ~ group_id_rand))$F[1]
@@ -189,7 +198,8 @@ These are removed for the calculation of rarefied richness."))
    
    p_S       = sum(F_obs$S       <= F_rand$S) / nperm
    p_N       = sum(F_obs$N       <= F_rand$N) / nperm
-   p_S_rare  = sum(F_obs$S_rare  <= F_rand$S_rare) / nperm
+   p_S_rare  = ifelse(!keep_rare_sample, NA, 
+                      sum(F_obs$S_rare  <= F_rand$S_rare) / nperm)
    p_PIE     = sum(F_obs$PIE     <= F_rand$PIE) / nperm
    p_ENS_PIE = sum(F_obs$ENS_PIE <= F_rand$ENS_PIE) / nperm
    p_S_asymp = sum(F_obs$S_asymp <= F_rand$S_asymp) / nperm


### PR DESCRIPTION
Bug report is #120 . Namely, when the treatment group / ref group were swapped, the legends changed accordingly but the rarefaction curves retained the same colors. This PR fixes the bug & ensures that the color-matching is correct for the pair-wise curves as long as `groups = c(trt_group, ref_group)`. 