### PR TITLE
Add average difference (D_bar) as measure of effect size in two-scale analysis

### DIFF
--- a/R/mobr.R
+++ b/R/mobr.R
@@ -497,7 +497,6 @@ avg_nn_dist = function(xy_coords) {
 #' @return a two column data.frame containing the number of individuals (inds)
 #'   and the difference in species richness (deltaS)
 #' @author Dan McGlinn and Xiao Xiao
-#' @importFrom pracma pchip
 #' @keywords internal
 deltaS_N = function(comm, ref_dens, inds){
     nplots = nrow(comm)

--- a/R/mobr_boxplots.R
+++ b/R/mobr_boxplots.R
@@ -545,15 +545,14 @@ get_mob_stats = function(mob_in, group_var,
     if ("f_0" %in% index) {
         gamma = with(dat_groups, value[index == "f_0"])
         alpha = with(dat_samples,  value[index == "f_0"])
-      
-        beta_S_asympS = gamma[group_id]/alpha
-        beta_S_asympS[!is.finite(beta_S_asympS)] = NA
+        beta_f_0 = gamma[group_id] / alpha
+        beta_f_0[!is.finite(beta_f_0)] = NA
       
         dat_beta_S_asympS = data.frame(group = group_id,
                                       index = "beta_f_0",
                                       effort = NA,
-                                      value = beta_S_asympS)
-        dat_samples = rbind(dat_samples, dat_beta_S_asympS)
+                                      value = beta_f_0)
+        dat_samples = rbind(dat_samples, dat_beta_f_0)
     }
    
     # Effective number of species based on PIE ----------------------------------

--- a/man/get_mob_stats.Rd
+++ b/man/get_mob_stats.Rd
@@ -145,15 +145,20 @@ alpha-diversity (i.e., average plot diversity).
 
 \strong{PERMUTATION TESTS AND BOOTSTRAP}
 
-We used permutation tests for assessing differences of the biodiversity
+For both the alpha and gamma scale analyses we summarize effect size in each
+biodiveristy index by computing \code{D_bar}: the average absolute difference
+between the groups. At the alpha scale the indices are averaged first before
+computing \code{D_bar}.
+
+We used permutation tests for testing differences of the biodiversity
 statistics among the groups (Legendre & Legendre 1998). At the alpha-scale,
 one-way ANOVA (i.e. F-test) is implemented by shuffling treatment group
-labels across samples.
-
-At the gamma-scale we aggregate the community matrix by summing across the 
-groups. Then we compute the mean difference in a given biodiversity index
-between the groups and perform a permutation test by shuffling the treatment
-group labels.
+labels across samples. The test statistic for this test is the F-statistic
+which is a pivotal statistic (Legendre & Legendre 1998). At the gamma-scale
+we carried out the permutation test by shuffling the treatment group labels
+and using \code{D_bar} as the test statistic. We could not use the
+F-statistic as the test statistic at the gamma scale because at this scale
+there are no replicates and therefore the F-statistic is undefined.
 
 A bootstrap approach can be used to also test differences at the gamma-scale.
 When \code{boot_groups = T} instead of the gamma-scale permutation test,


### PR DESCRIPTION
Several collaborators noted that although the F-statistic is a useful test statistic it is not the most useful measure of effect size because it is somewhat different to interpret. Therefore we have add the statistic `D_bar`, which is defined as the average of the absolute difference between treatments in the mean (at alpha scale) or raw (at gamma scale) biodiversity index, as a measure of effect size to the output of the function `get_mob_stats`.  `D_bar` was previously output only at the gamma scale where it is still used as a test statistic (in lieu of the F-stat).