### PR TITLE
Fix how the argument log is treated in the plotting functions

### DIFF
--- a/man/overlap_effects.Rd
+++ b/man/overlap_effects.Rd
@@ -6,8 +6,8 @@
 \usage{
 overlap_effects(mob_out, trt_group, display = "raw", prop = FALSE,
   rescale = "max_effort", common_scale = FALSE, xlabel_indiv = TRUE,
-  ylim = NULL, log = "", lty = 1, lwd = 3, col = c("#FFB3B5",
-  "#78D3EC", "#C5C0FE"))
+  ylim = NULL, log = "", lty = 1, lwd = 3, leg_loc = "topleft",
+  col = c("#FFB3B5", "#78D3EC", "#C5C0FE"))
 }
 \arguments{
 \item{mob_out}{a mob_out class object}
@@ -42,7 +42,11 @@ labeled with numbers of individuals}
 
 \item{lty}{a vector of line types, see \link[graphics]{par}.}
 
-\item{lwd}{a single value for for line width, see \link[graphics]{par}.}
+\item{lwd}{the line width, a single positive number, defaults to \code{3},
+see \code{\link[graphics]{par}} for more information.}
+
+\item{leg_loc}{the location of the legend. Defaults to 'topleft', see
+\code{\link[graphics]{legend}}. If set to NA then no legend is printed.}
 
 \item{col}{the colors for lines. Three colors can be specified so that each
 line can be given its own color with the curves ordered as SAD, N, and
@@ -62,7 +66,7 @@ data(inv_plot_attr)
 inv_mob_in = make_mob_in(inv_comm, inv_plot_attr)
 inv_mob_out = get_delta_stats(inv_mob_in, 'group', ref_group='uninvaded',
                               type='discrete', log_scale=TRUE, n_perm=2)
-overlap_effects(inv_mob_out, 'invaded')
+overlap_effects(inv_mob_out, 'invaded', leg_loc=NA)
 overlap_effects(inv_mob_out, 'invaded', display='stacked')
 overlap_effects(inv_mob_out, 'invaded', display='stacked', prop=TRUE)
 }

--- a/man/plot.mob_out.Rd
+++ b/man/plot.mob_out.Rd
@@ -5,8 +5,8 @@
 \title{Plot mob curves}
 \usage{
 \method{plot}{mob_out}(mob_out, trt_group, ref_group, same_scale = FALSE,
-  log = NULL, display = c("rarefaction", "delta S", "ddelta S"), lwd = 3,
-  par_args = NULL, ...)
+  log = "", display = c("rarefaction", "delta S", "ddelta S"), lwd = 3,
+  leg_loc = "topleft", par_args = NULL, ...)
 }
 \arguments{
 \item{mob_out}{a mob_out class object}
@@ -22,10 +22,14 @@ ddelta S plots are scaled identically across the tested effects}
     is to be logarithmic, \code{"y"} if the y axis is to be logarithmic
     and \code{"xy"} or \code{"yx"} if both axes are to be logarithmic.}
 
-\item{display}{argument specifies what graphics to display can be either
+\item{display}{a string that specifies what graphics to display can be either
 'rarefaction', 'delta S', or 'ddelta S' defaults to all three options.}
 
-\item{lwd}{a single value for for line width, see \link[graphics]{par}.}
+\item{lwd}{the line width, a single positive number, defaults to \code{3},
+see \code{\link[graphics]{par}} for more information.}
+
+\item{leg_loc}{the location of the legend. Defaults to 'topleft', see
+\code{\link[graphics]{legend}}. If set to NA then no legend is printed.}
 
 \item{par_args}{optional argument that sets graphical parameters to set}
 

--- a/man/plot_abu.Rd
+++ b/man/plot_abu.Rd
@@ -21,7 +21,8 @@ level or not}
 
 \item{col}{optional vector of colors.}
 
-\item{lwd}{a vector of line widths, see \code{\link[graphics]{par}}.}
+\item{lwd}{the line width, a single positive number, defaults to \code{3},
+see \code{\link[graphics]{par}} for more information.}
 
 \item{log}{a character string which contains \code{"x"} if the x axis
     is to be logarithmic, \code{"y"} if the y axis is to be logarithmic

--- a/man/plot_rarefaction.Rd
+++ b/man/plot_rarefaction.Rd
@@ -29,7 +29,8 @@ the individual based rarefaction is used (i.e., method = 'indiv')}
 
 \item{col}{optional vector of colors.}
 
-\item{lwd}{a single value for for line width, see \link[graphics]{par}.}
+\item{lwd}{the line width, a single positive number, defaults to \code{3},
+see \code{\link[graphics]{par}} for more information.}
 
 \item{log}{a character string which contains \code{"x"} if the x axis
     is to be logarithmic, \code{"y"} if the y axis is to be logarithmic

--- a/scripts/methods_ms_figures.R
+++ b/scripts/methods_ms_figures.R
@@ -2,7 +2,7 @@ library(mobr)
 
 data(inv_comm)
 data(inv_plot_attr)
-inv_mob_in= make_mob_in(inv_comm, inv_plot_attr)
+inv_mob_in = make_mob_in(inv_comm, inv_plot_attr)
 
 # run analyses
 inv_mob_stats = get_mob_stats(inv_mob_in, 'group', n_perm=999)
@@ -11,22 +11,22 @@ inv_mob_out = get_delta_stats(inv_mob_in, 'group', ref_group='uninvaded',
                            overall_p=TRUE)
 
 # create graphics
-pdf('./figs/inv_mob_stats.pdf', height=7*0.5)
+pdf('./figs/inv_mob_stats.pdf', height = 7*0.5)
 plot(inv_mob_stats)
 # additional plot of f0 without outline
-plot(inv_mob_stats, 'f_0', outline=F)
+plot(inv_mob_stats, 'f_0', outline = F)
 dev.off()
 
-pdf('./figs/inv_mob_stats_multi.pdf', width=7*1.25, height=7*2)
+pdf('./figs/inv_mob_stats_multi.pdf', width = 7*1.25, height = 7*2)
 plot(inv_mob_stats, multi_panel = T)
 plot(inv_mob_stats, multi_panel = T, outline = F)
 dev.off()
 
 pdf('./figs/inv_delta_stats.pdf')
-plot(inv_mob_out, 'invaded', 'uninvaded')
+plot(inv_mob_out, 'invaded', 'uninvaded', leg_loc = 'bottomright')
 dev.off()
 
 pdf('./figs/inv_mob_stacked.pdf')
-overlap_effects(inv_mob_out, 'invaded')
-overlap_effects(inv_mob_out, 'invaded', 'stacked', prop=T)
+overlap_effects(inv_mob_out, 'invaded', leg_loc = NA)
+overlap_effects(inv_mob_out, 'invaded', 'stacked', prop=T, leg_loc = NA)
 dev.off()


### PR DESCRIPTION
The argument `log` in the various plotting functions was generally correct except that in the function `plot.mob_out` when log was not specified the function looked to `mob_out$log_scale` if TRUE then it log transformed the x-axis. This will likely surprise users that therefore it is better for them to just expect arithmetic scaling unless they specifically ask for a log transformation. Also these changes make is so that the specification of a log transformation is as is expected by `plot.default` which should increase usability. 

I also updated the documentation on several arguments in the plotting functions and made them more consistent. I improved the use of the argument `leg_loc` which specifies the location of a legend. This is now available in the function `overlap_effects`.