### PR TITLE
Allow specification of rare_thres as "N/S" 

### DIFF
--- a/man/calc_biodiv.Rd
+++ b/man/calc_biodiv.Rd
@@ -21,7 +21,7 @@ sites by species table.}
    \item \code{S_n} ... Rarefied or extrapolated number of species for n individuals
    \item \code{S_asymp} ... Estimated asymptotic species richness
    \item \code{f_0} ... Estimated number of undetected species 
-   \item \code{pct_rare} ... The percent of rare species
+   \item \code{pct_rare} ... The percent of species with abundances below \code{rare_thres}
    \item \code{PIE} ... Hurlbert's PIE (Probability of Interspecific Encounter)
    \item \code{S_PIE} ... Effective number of species based on PIE
 }
@@ -33,10 +33,12 @@ biodiversity indices.}
 calculation of rarefied species richness. This can a be
 single value or an integer vector.}
 
-\item{rare_thres}{The threshold for determining if a species is rare or not. 
-It can ranges from (0, 1] and defaults to 0.05 which specifies that any 
+\item{rare_thres}{The threshold that determines how pct_rare is computed.
+It can range from (0, 1] and defaults to 0.05 which specifies that any 
 species with less than or equal to 5% of the total abundance in a sample is
-considered rare.}
+considered rare. It can also be specified as "N/S" which results in using
+average abundance as the threshold which McGill (2011) found to have the 
+best small sample behavior.}
 }
 \value{
 A dataframe with four columns:
@@ -54,6 +56,11 @@ Calculate biodiversity statistics from sites by species table.
 \details{
 This function is primarily intended as auxiliary function used in
 \code{\link{get_mob_stats}}, but can be also used directly for data exploration.
+}
+\references{
+McGill, B. J. 2011. Species abundance distributions. Pages 105–122 Biological
+Diversity: Frontiers in Measurement and Assessment, eds. A.E. Magurran and
+B.J. McGill.
 }
 \author{
 Felix May and Dan McGlinn

--- a/man/get_mob_stats.Rd
+++ b/man/get_mob_stats.Rd
@@ -42,10 +42,12 @@ individuals then \code{effort_min} are excluded from the analysis with a
 warning. Accordingly, when \code{effort_samples} is set by the user it has
 to be higher than \code{effort_min}.}
 
-\item{rare_thres}{The threshold for determining if a species is rare or not. 
-It can ranges from (0, 1] and defaults to 0.05 which specifies that any 
+\item{rare_thres}{The threshold that determines how pct_rare is computed.
+It can range from (0, 1] and defaults to 0.05 which specifies that any 
 species with less than or equal to 5% of the total abundance in a sample is
-considered rare.}
+considered rare. It can also be specified as "N/S" which results in using
+average abundance as the threshold which McGill (2011) found to have the 
+best small sample behavior.}
 
 \item{n_perm}{The number of permutations to use for testing for treatment
 effects.}


### PR DESCRIPTION
This allows the percent rare metric to be computed using average abundance rather than at a set percentage. 