### PR TITLE
 Important changes to get_mob_stats and rarefaction functions

### DIFF
--- a/R/mobr_boxplots.R
+++ b/R/mobr_boxplots.R
@@ -1111,8 +1111,6 @@ plot.mob_stats = function(mob_stats, index = NULL, multi_panel = FALSE,
                                        list(n = effort_samples[i]))
                 samples_panel1(dat_samples, dat_tests, main = '',
                                ylab = "", col = col, cex.axis=cex.axis, ...)
-                #main = expression(beta * "-diversity (=" *
-                #                                 gamma / alpha * "), n=" * )
 
                 par(new=TRUE)
                 plot(1:10, 1:10, type='n', axes=F, xlab='', ylab='',

--- a/man/calc_biodiv.Rd
+++ b/man/calc_biodiv.Rd
@@ -4,7 +4,8 @@
 \alias{calc_biodiv}
 \title{Calculate biodiversity statistics from sites by species table.}
 \usage{
-calc_biodiv(abund_mat, groups, index, effort, rare_thres)
+calc_biodiv(abund_mat, groups, index, effort, extrapolate, return_NA,
+  rare_thres)
 }
 \arguments{
 \item{abund_mat}{Sites by species table with species abundances
@@ -32,6 +33,10 @@ biodiversity indices.}
 \item{effort}{The standardized number of individuals used for the 
 calculation of rarefied species richness. This can a be
 single value or an integer vector.}
+
+\item{extrapolate}{boolean which specifies if richness should be extrapolated
+when effort is larger than the number of individuals using the chao1
+method.}
 
 \item{rare_thres}{The threshold that determines how pct_rare is computed.
 It can range from (0, 1] and defaults to 0.05 which specifies that any 

--- a/man/get_mob_stats.Rd
+++ b/man/get_mob_stats.Rd
@@ -5,8 +5,9 @@
 \title{Calculate sample based and group based biodiversity statistics.}
 \usage{
 get_mob_stats(mob_in, group_var, index = c("N", "S", "S_n", "pct_rare",
-  "S_PIE"), effort_samples = NULL, effort_min = 5, rare_thres = 0.05,
-  n_perm = 199, boot_groups = F, conf_level = 0.95, cl = NULL, ...)
+  "S_PIE"), effort_samples = NULL, effort_min = 5, extrapolate = TRUE,
+  return_NA = FALSE, rare_thres = 0.05, n_perm = 199, boot_groups = F,
+  conf_level = 0.95, cl = NULL, ...)
 }
 \arguments{
 \item{mob_in}{an object of class mob_in created by make_mob_in()}
@@ -41,6 +42,15 @@ calculation of rarefied richness (Default value of 5). Samples with less
 individuals then \code{effort_min} are excluded from the analysis with a
 warning. Accordingly, when \code{effort_samples} is set by the user it has
 to be higher than \code{effort_min}.}
+
+\item{extrapolate}{extrapolate    boolean which specifies if richness should be
+extrapolated when \code{effort_samples} is larger than the number of
+individuals using the chao1 method. Defaults to TRUE.}
+
+\item{return_NA}{boolean defaults to FALSE in which the rarefaction function
+returns the observed S when \code{effort} is larger than the number of
+individuals . If set to TRUE then NA is returned. Note that this argument
+is only relevant when \code{extrapolate = FALSE}.}
 
 \item{rare_thres}{The threshold that determines how pct_rare is computed.
 It can range from (0, 1] and defaults to 0.05 which specifies that any 
@@ -98,8 +108,9 @@ scale linearly with sample area or effort, at the gamma-scale the number of
 individuals for rarefaction is calculated as the minimum number of samples
 within groups multiplied by \code{effort_samples}. For example, when there are 10
 samples within each group, \code{effort_groups} equals \code{10 *
-effort_samples}. If n is larger than the number of individuals in sample then
-the Chao1 (Chao 1984, Chao 1987) method is used to extrapolate the rarefaction curve. 
+effort_samples}. If n is larger than the number of individuals in sample and
+\code{extrapolate = TRUE} then the Chao1 (Chao 1984, Chao 1987) method is
+used to extrapolate the rarefaction curve.
 
 \strong{pct_rare: Percent of rare species} Is the ratio of the number of rare
 species to the number of observed species x 100 (McGill 2011). Species are 

--- a/man/rarefaction.Rd
+++ b/man/rarefaction.Rd
@@ -5,7 +5,8 @@
 \title{Rarefied Species Richness}
 \usage{
 rarefaction(x, method, effort = NULL, coords = NULL, latlong = NULL,
-  dens_ratio = 1, extrapolate = FALSE, quiet_mode = FALSE)
+  dens_ratio = 1, extrapolate = FALSE, return_NA = FALSE,
+  quiet_mode = FALSE)
 }
 \arguments{
 \item{x}{can either be a: 1) mob_in object, 2) community matrix-like
@@ -43,6 +44,12 @@ when effort is larger than the number of individuals using the chao1 method.
 Defaults to FALSE in which case it returns observed richness. Extrapolation
 is only implemented for individual-based rarefaction 
 (i.e., \code{method = 'indiv'})}
+
+\item{return_NA}{boolean defaults to FALSE in which the function returns the
+observed S when \code{effort} is larger than the number of individuals or
+number of samples (depending on the method of rarefaction). If set to TRUE
+then NA is returned. Note that this argument is only relevant when
+\code{extrapolate = FALSE}.}
 
 \item{quiet_mode}{boolean defaults to FALSE, if TRUE then warnings and other
 non-error messages are suppressed.}


### PR DESCRIPTION
* Implement new beta_S_n calculation and associated graphics that uses the same value of n at the alpha and gamma scales as described in #213.

* added back the computation of beta_S_asymp as it may be of interest to some users

* improve user control over rarefaction when user specified effort is larger than observed in the sample by adding the return_NA argument and by improving the warning messages. Previously, the function rarefaction would either return an extrapolated S value using Chao1 or just the observed S of the SAD. Now there is the option to make the function return NA when effort > N. This is useful when using the get_mob_stats function because a user may wish to only analyze plots that have at least effort amount of individuals. 