### PR TITLE
control for fail when effort = NA and index = 'S_n'

### DIFF
--- a/R/mobr_boxplots.R
+++ b/R/mobr_boxplots.R
@@ -158,7 +158,7 @@ boot_sample_groups = function(abund_mat, index, effort, extrapolate, return_NA,
 #' @examples  
 #' data(inv_comm)
 #' calc_div(inv_comm[1, ], 'S_n', effort = c(5, 10))
-calc_div = function(x, index, effort = NA, rare_thres = 0.05, ...) {
+calc_div = function(x, index, effort, rare_thres = 0.05, ...) {
     if (index == 'N') out = sum(x)
     if (index == 'S') out = sum(x > 0)
     if (index == 'S_n') out = rarefaction(x, method = 'IBR', effort = effort, ...) 
@@ -258,6 +258,7 @@ calc_comm_div = function(abund_mat, index, effort = NA,
     out = vector('list', length = length(index))
     names(out) = index
     # compute indices ---------------------------------------------------------
+	if (any(index == 'S_n') && is.na(effort)) stop('effort value is needed to compute S_n')
     for (i in seq_along(index)) {
         if (any(c('alpha','beta') %in% scales)) 
             alpha = apply(abund_mat, 1, calc_div, index[i], effort, rare_thres,


### PR DESCRIPTION
In calc_div, instead of deleting the default parameter for effort, a similar check as in calc_comm_div could be made.
With this change, the errors are more informative:
Before:
```
> data(inv_comm)
> calc_comm_div(inv_comm, 'S_n')
Error in if (any(effort > n)) { : missing value where TRUE/FALSE needed
> calc_div(inv_comm[1,], 'S_n')
Error in if (any(effort > n)) { : missing value where TRUE/FALSE needed
```
After:
```
> calc_comm_div(inv_comm, 'S_n')
Error in calc_comm_div(inv_comm, "S_n") : 
  effort value is needed to compute S_n
> calc_div(inv_comm[1, ], 'S_n')
Error in rarefaction(x, method = "IBR", effort = effort, ...) : 
  argument "effort" is missing, with no default
```
