### PR TITLE
Spatially-explicit rarefaction

### DIFF
--- a/R/mobr.R
+++ b/R/mobr.R
@@ -254,13 +254,13 @@ sphere_dist = function(coords, r = 6378.137){
 #' @param quiet_mode Boolean defaults to FALSE, if TRUE then warnings and other
 #'   non-error messages are suppressed.
 #' @param spat_algo character string that can be either: \code{'kNN'},
-#' \code{'kNCN'}, or \code{'convexhull'} for k-nearest neighbor, 
-#' k-nearest centroid neighbor sampling, or convex-hull polygon calculation 
-#' respectively. It defaults to k-nearest neighbor which is a 
-#' more computationally efficient algorithm that closely approximates the 
-#' potentially more correct k-NCN algo (see Details). Currently, \code{'kNN'} and
-#' \code {'k-NCN'} are available for method \code{'ssBR'}, while \code{'kNN'}
-#' \code{'convexhull'} are available for method \code{'spexSBR'}. 
+#'  \code{'kNCN'}, or \code{'convexhull'} for k-nearest neighbor, 
+#'  k-nearest centroid neighbor sampling, or convex-hull polygon calculation 
+#'  respectively. It defaults to k-nearest neighbor which is a 
+#'  more computationally efficient algorithm that closely approximates the 
+#'  potentially more correct k-NCN algo (see Details). Currently, \code{'kNN'} and
+#'  \code{'k-NCN'} are available for method \code{'ssBR'}, while \code{'kNN'}
+#'  \code{'convexhull'} are available for method \code{'spexSBR'}. 
 #' @param sd Boolean defaults to FALSE, if TRUE then standard deviation of 
 #' richness is also returned using the formulation of Heck 1975 Eq. 2.
 #'   

--- a/man/rarefaction.Rd
+++ b/man/rarefaction.Rd
@@ -40,13 +40,14 @@ a vector which contains the abundance of each species.}
     \item \code{'sSBR'} ... spatial sample-based rarefaction in which species 
     are accumulated by including spatially proximate samples first.
     \item \code{'spexSBR'}  ... spatially-explicit sample-based rarefaction
-    in which species are accumulated as in \code{'spexSBR'} but sampling
+    in which species are accumulated as in \code{'sSBR'} but sampling
     effort is not measured by no. of samples, but by cumulative distance or
     cumulative area as specified by \code{'spat_algo'} (see details)
 }}
 
-\item{effort}{optional argument to specify what number of individuals or 
-number of samples depending on 'method' to compute rarefied richness as. If
+\item{effort}{optional argument to specify what number of individuals, 
+number of samples, or spatial sampling effort (i.e., cumulative distance
+or area) depending on 'method' to compute rarefied richness as. If
 not specified all possible values from 1 to the maximum sampling effort are
 used}
 
@@ -78,11 +79,14 @@ then NA is returned. Note that this argument is only relevant when
 \item{quiet_mode}{Boolean defaults to FALSE, if TRUE then warnings and other
 non-error messages are suppressed.}
 
-\item{spat_algo}{character string that can be either: \code{'kNN'} or \code{'kNCN'}
-for k-nearest neighbor and k-nearest centroid neighbor sampling 
+\item{spat_algo}{character string that can be either: \code{'kNN'},
+\code{'kNCN'}, or \code{'convexhull'} for k-nearest neighbor, 
+k-nearest centroid neighbor sampling, or convex-hull polygon calculation 
 respectively. It defaults to k-nearest neighbor which is a 
 more computationally efficient algorithm that closely approximates the 
-potentially more correct k-NCN algo (see Details).}
+potentially more correct k-NCN algo (see Details). Currently, \code{'kNN'} and
+\code{'k-NCN'} are available for method \code{'ssBR'}, while \code{'kNN'}
+\code{'convexhull'} are available for method \code{'spexSBR'}.}
 
 \item{sd}{Boolean defaults to FALSE, if TRUE then standard deviation of 
 richness is also returned using the formulation of Heck 1975 Eq. 2.}
@@ -112,6 +116,8 @@ The analytical formulas of Cayuela et al. (2015) are used to compute
   kNN and kNCN, each plot in the community matrix is treated as a starting
   point and then the mean of these n possible accumulation curves is
   computed.
+  
+  
 
 For individual-based rarefaction if effort is greater than the number of
 individuals and \code{extrapolate = TRUE} then the Chao1 method is used 


### PR DESCRIPTION
Hi Dan, 
as last action before my summer vacation, here is the PR I announced quite a while ago.
In contrast to your suggestions, I did NOT create a new function, but added changes to `rarefaction` as a central function of mobr. 

I also noticed that erroneously pushed changes during the last month (my last 3 commits) directly to MoBiodiv::mobr::dev and NOT to FelixMay::mobr::dev. I am sorry for this!!! So this PR just includes one commit. I will watch out my push settings more carefully next time (too much automatism in RStudio). Well, I think undoing commits is easy if you want.

But how to proceed: I guess the key question is if you want to integreate spexSBR (or however we might call that in the future) into mobr::master or if I should rather add it as function to spatialbiodiv. I am fine with either option.

In any case the spexSBR function needs adjustments. I noted there are two decision on spatial algorithms:

1. How do you accumulate points (kNN or kNCN)
2. How do you calculate spatial sampling effort for a given set of points. I think the convex-hull makes most sense here, but of course there are other options.

What about talking about these issues ina  video call some time in September (after my vacation)?

best,

Felix

