### PR TITLE
Fix small bug and bring plot.mob_stats back

### DIFF
--- a/R/mobr.R
+++ b/R/mobr.R
@@ -1352,10 +1352,10 @@ get_delta_stats = function(mob_in, env_var, group_var=NULL, ref_level = NULL,
 #' inv_mob_in <- make_mob_in(inv_comm, inv_plot_attr, coord_names = c('x', 'y'))
 #' plot_abu(inv_mob_in, 'group', 'uninvaded', type='sad', log='x')
 #' plot_abu(inv_mob_in, 'group', 'uninvaded', type='rad', scale = 'alpha', log='x')
-plot_abu = function(mob_in, group_var, ref_level = NULL, type = 'sad',
+plot_abu <- function(mob_in, group_var, ref_level = NULL, type = 'sad',
                     scale = 'gamma', col=NULL, lwd=3, log='',
                     leg_loc = 'topleft') {
-    groups  = factor(mob_in$env[ , group_var])
+    groups = factor(mob_in$env[ , group_var])
     group_levels = levels(groups) 
     # issue warning if all groups do not have equal replication
     if (length(unique(table(groups))) > 1)
@@ -1402,9 +1402,10 @@ plot_abu = function(mob_in, group_var, ref_level = NULL, type = 'sad',
                 }
             }
         }
+      mtext(type, side=3)
     } 
     if ('rad' == type) {
-        plot(1:10, 1:10, type = 'n', xlab = 'rank', ylab = 'abundance',
+        plot(1, type = 'n', xlab = 'rank', ylab = 'abundance',
              log = log, xlim = c(1, ncol(mob_in$comm)), 
              ylim = range(0.01, 1), cex.lab = 1.5, cex.axis = 1.5,
              main = title)
@@ -1420,13 +1421,15 @@ plot_abu = function(mob_in, group_var, ref_level = NULL, type = 'sad',
              } 
              if (scale == 'alpha') {
                  for (j in 1:nrow(comm_grp)) {
-                     sad_sort = sort(as.numeric(comm_grp[j, comm_grp[j, ] != 0]), decreasing = TRUE)
+                     sad_sort = sort(as.numeric(comm_grp[j, comm_grp[j, ] != 0]),
+                                     decreasing = TRUE)
                      lines(1:length(sad_sort), sad_sort / sum(sad_sort),
                            col = scales::alpha(col_grp, 0.5),
                            lwd = lwd, type = "l")
                  }     
              }
         }
+      mtext(type, side=3)
     }
     if (!is.na(leg_loc))
         legend(leg_loc, legend = group_levels, col = col, lwd = lwd, bty = 'n')
@@ -1502,7 +1505,8 @@ plot_rarefaction = function(mob_in, group_var, ref_level = NULL,
                             scales = c('alpha', 'gamma', 'study'),  
                             raw = TRUE, smooth = FALSE, avg = FALSE, 
                             col = NULL, lwd = 3, log = '',
-                            leg_loc = 'topleft', one_panel = FALSE, ...) {
+                            leg_loc = 'topleft', one_panel = FALSE,
+                            method_label = TRUE, ...) {
     if ('alpha' %in% scales & method != 'IBR') {
         warning('Sample based rarefaction methods do not make sense at alpha scale, dropping alpha scale curves')
         scales <- scales[scales != 'alpha']
@@ -1625,6 +1629,8 @@ plot_rarefaction = function(mob_in, group_var, ref_level = NULL,
                      type = 'l')
           }
         }
+        if (method_label)
+           mtext(method, side = 3)
     }    
     if ('gamma' %in% scales) {
       if (!one_panel) {
@@ -1658,6 +1664,8 @@ plot_rarefaction = function(mob_in, group_var, ref_level = NULL,
           lines(n, Savg, lwd = lwd, lty=2, 
                 col=mean_col(col[1:length(group_levels)]))
         }
+        if (method_label)
+          mtext(method, side = 3)
       }
     }
     if ('study' %in% scales & !('gamma' %in% scales)) {
@@ -1683,6 +1691,8 @@ plot_rarefaction = function(mob_in, group_var, ref_level = NULL,
           lines(1:nmax, Savg[1:nmax], lwd = lwd, lty=2, 
                 col=mean_col(col[1:length(group_levels)]))
       }
+      if (method_label)
+        mtext(method, side = 3)
       
     }
 

--- a/R/mobr_boxplots.R
+++ b/R/mobr_boxplots.R
@@ -479,7 +479,7 @@ calc_comm_div = function(abund_mat, index, effort = NA,
         sample_size <- nrow(abund_mat)
         if ('alpha' %in% scales) {
             if (avg_alpha) 
-                alpha <- mean(alpha)
+                alpha <- mean(alpha, na.rm = TRUE)
             out[[i]]$alpha = data.frame(scale = 'alpha', index = index[i],
                                         sample_size = ifelse(avg_alpha, sample_size, 1),
                                         effort = effort_out,
@@ -634,9 +634,10 @@ calc_comm_div_ci <- function(samples, cent_stat = 'median', ci = c(0.025, 0.975)
             sample_size = mean(.data$sample_size),
             effort = mean(effort),
             gamma_coverage = mean(.data$gamma_coverage),
-            lo_value = quantile(.data$value, ci[1]),
-            hi_value = quantile(.data$value, ci[2]), 
-            value = ifelse(cent_stat == 'avg', mean(.data$value), median(.data$value)),
+            lo_value = quantile(.data$value, ci[1], na.rm = TRUE),
+            hi_value = quantile(.data$value, ci[2], na.rm = TRUE), 
+            value = ifelse(cent_stat == 'avg', mean(.data$value, na.rm = TRUE),
+                           median(.data$value, na.rm = TRUE)),
             .groups = 'keep')
 
     return(data.frame(sample_qts))

--- a/R/mobr_boxplots.R
+++ b/R/mobr_boxplots.R
@@ -734,7 +734,8 @@ get_mob_stats <- function(mob_in, group_var, ref_level = NULL,
                           scales = c('alpha', 'gamma', 'beta'),
                           PIE_replace = FALSE, C_target_gamma = NA,
                           n_perm = 199, cl = NULL, 
-                          ci = TRUE, ci_cent_stat = 'median', ci_algo = 'loo', ...) {
+                          ci = TRUE, ci_cent_stat = 'median', ci_algo = 'loo',
+                          ci_n_boot = 1000, ...) {
   EPS <- sqrt(.Machine$double.eps)
   if (n_perm < 1) 
     stop('Set n_perm to a value greater than 1') 
@@ -746,20 +747,7 @@ get_mob_stats <- function(mob_in, group_var, ref_level = NULL,
   
   groups <- factor(mob_in$env[ , group_var])
   group_levels <- levels(groups) 
-  # ensure that proper contrasts in groups specify the reference level as 
-  # first group so downstream graphics have reference level in
-  # leftmost boxplot panel
-  if (!is.null(ref_level)) { 
-    if (ref_level %in% group_levels) {
-      if (group_levels[1] != ref_level) {
-        groups <- factor(groups, levels = c(ref_level, group_levels[group_levels != ref_level]))
-        group_levels <- levels(groups)
-      }
-    } else
-      stop(paste(ref_level, "is not in", group_var))
-  }
-  
-  
+
   # Get rarefaction level
   samples_N <- rowSums(mob_in$comm) 
   samples_per_group <- table(groups)
@@ -786,7 +774,8 @@ get_mob_stats <- function(mob_in, group_var, ref_level = NULL,
     cat('\nComputing confidence intervals\n')
     sample_list <- data.frame(groups, mob_in$comm) |> 
       group_by(groups) |> 
-      group_map(~ get_samples(.x))
+      group_map(~ get_samples(.x, algo = ci_algo, 
+                              n_boot = ci_n_boot))
     names(sample_list) <- group_levels
     if (is.null(C_target_gamma)) {
       # compute C_target_gamma across two groups
@@ -875,13 +864,29 @@ get_mob_stats <- function(mob_in, group_var, ref_level = NULL,
   perm_tests <- perm_tests[order(perm_tests$index), ]
   perm_tests$index <- factor(perm_tests$index)
   
+  # ensure that proper contrasts in groups specify the reference level as 
+  # first group so downstream graphics have reference level in
+  # leftmost boxplot panel
+  groups <- dat_div[[group_var]]
+  group_levels <- unique(groups)
+  if (!is.null(ref_level)) { 
+    if (ref_level %in% group_levels) {
+      if (group_levels[1] != ref_level) {
+        groups <- factor(groups, levels = c(ref_level, group_levels[group_levels != ref_level]))
+        group_levels <- levels(groups)
+      }
+    } else
+      stop(paste(ref_level, "is not in", group_var))
+  }
+  dat_div[[group_var]] <- factor(dat_div[[group_var]],
+                                 levels = group_levels)
   
   # create output
   out <- list(comm_div = dat_div,
               group_tests = perm_tests)
   if ("pct_rare" %in% index)
-    out$rare_thres = rare_thres
-  class(out) = 'mob_stats'
+    out$rare_thres <- rare_thres
+  class(out) <- 'mob_stats'
   return(out)
 }
 
@@ -892,43 +897,73 @@ get_mob_stats <- function(mob_in, group_var, ref_level = NULL,
 #' function \code{\link{get_mob_stats}}. The p-value for each statistic
 #' is displayed in the plot title if applicable.
 #' 
-#' The user may specify which results to plot or simply to plot 
-#' all the results. 
-#' 
-#' @param x a \code{mob_stats} object that has the samples and 
-#' treatment level statistics
-#' 
-#' @param index The biodiversity statistics that should be plotted.
-#' See \code{\link{get_mob_stats}} for information on the indices. By default there
-#' is one figure for each index, with panels for alpha- and gamma-scale results
-#' as well as for beta-diversity when applicable. 
-#' 
-#' @param multi_panel A logical variable. If \code{multi_panel = TRUE} then a 
-#' multipanel plot is produced, which shows observed, rarefied, and asymptotic 
-#' species richness and S_PIE at the alpha- and gamma-scale.
-#' This set of variables conveys a comprehensive picture of the underlying 
-#' biodiversity changes. 
-#' 
-#' @param col a vector of colors for the groups, set to NA if no color is
-#' preferred
-#' 
-#' @param cex.axis The magnification to be used for axis annotation relative to
-#' the current setting of cex. Defaults to 1.2. 
-#' 
-#' @param ... additional arguments to provide to \code{boxplot}, \code{points},
-#'   and confidence interval functions
-#' 
-#' @author Felix May, Xiao Xiao, and Dan McGlinn 
+#' @param mob_stats a \code{mob_stats} object produced by the function
+#'   \code{\link{get_mob_stats}}
+#'   
+#' @param group_var a character string which specifies which variable provides
+#'   the groups that the diversity indices are compared across. 
 #' 
 #' @importFrom rlang .data
 #' 
 #' @export
-plot.mob_stats = function(x, index = NULL, multi_panel = FALSE, 
-                          col = c("#FFB3B5", "#78D3EC", "#6BDABD", "#C5C0FE",
-                                  "#E2C288", "#F7B0E6", "#AAD28C"), 
-                          cex.axis=1.2, ...) {
-  stop('This function is obsolete and no longer supported. Now use "plot_comm_div"
-       to plot the output of "calc_comm_div"')
+#' @examples
+#' data(tank_comm)
+#' data(tank_plot_attr)
+#' tank_mob <- make_mob_in(tank_comm, tank_plot_attr)
+#' # for quick results we specify a low number of permutations 
+#' # and bootstrap samples these should be increased in real 
+#' # analyses. 
+#' tank_stats <- get_mob_stats(tank_mob, 'group', 'low',
+#'                             index = c('S', 'S_PIE', 'S_C'),
+#'                             n_perm = 19, ci_algo = 'boot', ci_n_boot = 20)
+#' p <- plot(tank_stats, 'group')
+#' # plot of S
+#' p$S
+#' # plot of S_PIE
+#' p$S_PIE
+#' # plot of S_C
+#' p$S_C
+plot.mob_stats <- function(mob_stats, group_var) {
+  all_stats <- dplyr::left_join(mob_stats$comm_div, mob_stats$group_tests,
+                                by=c('scale', 'index'))
+  indices <- sub("beta_", "", all_stats$index)
+  uni_index <- unique(indices)
+  p <- vector('list', length = length(uni_index))
+  names(p) <- uni_index
+  
+  for (i in seq_along(uni_index)) {
+    tmp <- subset(all_stats, indices == uni_index[i])
+    group <- tmp[[group_var]]
+    # setup y-axis label
+    y_label <- switch(uni_index[i],
+                      "N" = expression("Abundance (" * italic(N) * ")"),
+                      "S" = expression('Richness (' * italic(S) * ')'),
+                      "S_C" = expression('Richness (' * italic(S)[C] *')'),
+                      "S_asymp" = expression('Asympotic richness (' *
+                                               italic(S[asymp]) * ')'),
+                      "pct_rare" = paste("% of species in lower",
+                                         ifelse(is.character(mob_stats$rare_thres),
+                                                mob_stats$rare_thres,
+                                                mob_stats$rare_thres * 100),
+                                         "% of abundance"),
+                      "f_0" = expression('Undetected richness (' * italic(f)[0] * ')'),
+                      "S_PIE" = expression('ENS of PIE (' * italic(S)[PIE] * ')'))
+    labs <- with(tmp, paste(scale, "\nDbar = ", round(D_bar, 1),
+                            ", p = ", round(p_val, 3), sep=""))
+    names(labs) <- tmp$scale
+    p[[i]] <- ggplot(tmp, aes(group, value)) +
+      geom_point() + 
+      geom_errorbar(aes(group, value,
+                        ymin = lo_value, ymax = hi_value),
+                     width = 0.2) +
+      ylab(y_label) + 
+      facet_wrap(vars(scale), scales = 'free', 
+                 labeller = as_labeller(labs)) + 
+      xlab(group_var) + 
+      theme_classic()
+
+  }
+  return(p)
 }
 
 #' Panel function for alpha-scale results
@@ -1033,6 +1068,8 @@ groups_panel2 = function(group_dat, col, ylab = "",
 #' data(tank_comm)
 #' data(tank_plot_attr)
 #' indices <- c('N', 'S', 'S_C', 'S_n', 'S_PIE')
+#' # the grouping variable must be called group in the 
+#' # tank_div data.frame
 #' tank_div <- tibble(tank_comm) |> 
 #'   group_by(group = tank_plot_attr$group) |> 
 #'   group_modify(~ calc_comm_div(.x, index = indices, effort = 5,

--- a/man/get_mob_stats.Rd
+++ b/man/get_mob_stats.Rd
@@ -7,7 +7,6 @@
 get_mob_stats(
   mob_in,
   group_var,
-  ref_level = NULL,
   index = c("N", "S", "S_n", "S_PIE"),
   effort_samples = NULL,
   effort_min = 5,
@@ -21,7 +20,7 @@ get_mob_stats(
   cl = NULL,
   ci = TRUE,
   ci_cent_stat = "median",
-  ci_algo = "loo",
+  ci_algo = "boot",
   ci_n_boot = 1000,
   ...
 )
@@ -31,10 +30,6 @@ get_mob_stats(
 
 \item{group_var}{String that specifies which variable in \code{mob_in$env} the
 data should be grouped by.}
-
-\item{ref_level}{String that defines the reference level of \code{group_var}
-to which all other groups are compared with, defaults to \code{NULL}.
-If \code{NULL} then the default contrasts of \code{group_var} are used.}
 
 \item{index}{The calculated biodiversity indices. The options are
 \itemize{
@@ -115,7 +110,7 @@ to TRUE.}
 specifies the measure of central tendency. Defaults to 'median'.}
 
 \item{ci_algo}{can be either 'boot' or 'loo' for bootstrap or leave-one-out
-methods respectively. Default value is 'loo'.}
+methods respectively. Default value is 'boot'.}
 
 \item{...}{additional arguments that can be passed to \code{\link{calc_div}}}
 }
@@ -158,9 +153,9 @@ result in a \code{D_bar} as large as the observed \code{D_bar} value.
 data(tank_comm)
 data(tank_plot_attr)
 tank_mob <- make_mob_in(tank_comm, tank_plot_attr)
-tank_stats <- get_mob_stats(tank_mob, 'group', 'low', index = c('S', 'S_PIE', 'S_C'),
+tank_stats <- get_mob_stats(tank_mob, 'group', index = c('S', 'S_PIE', 'S_C'),
                             n_perm = 19)
-tank_stats          
+tank_stats    
 }
 \references{
 Chao, A. 1984. Nonparametric Estimation of the Number of Classes in a

--- a/man/get_mob_stats.Rd
+++ b/man/get_mob_stats.Rd
@@ -22,6 +22,7 @@ get_mob_stats(
   ci = TRUE,
   ci_cent_stat = "median",
   ci_algo = "loo",
+  ci_n_boot = 1000,
   ...
 )
 }

--- a/man/plot.mob_stats.Rd
+++ b/man/plot.mob_stats.Rd
@@ -4,7 +4,7 @@
 \alias{plot.mob_stats}
 \title{Plot statistics for a MoB analysis}
 \usage{
-\method{plot}{mob_stats}(mob_stats, group_var)
+\method{plot}{mob_stats}(mob_stats, group_var, group_order = NULL)
 }
 \arguments{
 \item{mob_stats}{a \code{mob_stats} object produced by the function
@@ -12,6 +12,10 @@
 
 \item{group_var}{a character string which specifies which variable provides
 the groups that the diversity indices are compared across.}
+
+\item{group_order}{Optional vector of group levels the order of 
+which defines the order in which the groups are plotted from left-to-right. 
+Note that the default in R is to order groups alphabetically.}
 }
 \description{
 Plots a \code{mob_stats} object which is produced by the 
@@ -25,14 +29,13 @@ tank_mob <- make_mob_in(tank_comm, tank_plot_attr)
 # for quick results we specify a low number of permutations 
 # and bootstrap samples these should be increased in real 
 # analyses. 
-tank_stats <- get_mob_stats(tank_mob, 'group', 'low',
-                            index = c('S', 'S_PIE', 'S_C'),
-                            n_perm = 19, ci_algo = 'boot', ci_n_boot = 20)
+tank_stats <- get_mob_stats(tank_mob, 'group',
+                            index = c('N', 'S', 'S_n', 'S_PIE', 'S_C'),
+                            n_perm = 19, ci_n_boot = 20)
 p <- plot(tank_stats, 'group')
 # plot of S
 p$S
-# plot of S_PIE
-p$S_PIE
-# plot of S_C
-p$S_C
+# change the order of the groups on the plot
+p <- plot(tank_stats, 'group', group_order = c('low', 'high'))
+p$S
 }

--- a/man/plot.mob_stats.Rd
+++ b/man/plot.mob_stats.Rd
@@ -4,48 +4,35 @@
 \alias{plot.mob_stats}
 \title{Plot statistics for a MoB analysis}
 \usage{
-\method{plot}{mob_stats}(
-  x,
-  index = NULL,
-  multi_panel = FALSE,
-  col = c("#FFB3B5", "#78D3EC", "#6BDABD", "#C5C0FE", "#E2C288", "#F7B0E6", "#AAD28C"),
-  cex.axis = 1.2,
-  ...
-)
+\method{plot}{mob_stats}(mob_stats, group_var)
 }
 \arguments{
-\item{x}{a \code{mob_stats} object that has the samples and 
-treatment level statistics}
+\item{mob_stats}{a \code{mob_stats} object produced by the function
+\code{\link{get_mob_stats}}}
 
-\item{index}{The biodiversity statistics that should be plotted.
-See \code{\link{get_mob_stats}} for information on the indices. By default there
-is one figure for each index, with panels for alpha- and gamma-scale results
-as well as for beta-diversity when applicable.}
-
-\item{multi_panel}{A logical variable. If \code{multi_panel = TRUE} then a 
-multipanel plot is produced, which shows observed, rarefied, and asymptotic 
-species richness and S_PIE at the alpha- and gamma-scale.
-This set of variables conveys a comprehensive picture of the underlying 
-biodiversity changes.}
-
-\item{col}{a vector of colors for the groups, set to NA if no color is
-preferred}
-
-\item{cex.axis}{The magnification to be used for axis annotation relative to
-the current setting of cex. Defaults to 1.2.}
-
-\item{...}{additional arguments to provide to \code{boxplot}, \code{points},
-and confidence interval functions}
+\item{group_var}{a character string which specifies which variable provides
+the groups that the diversity indices are compared across.}
 }
 \description{
 Plots a \code{mob_stats} object which is produced by the 
 function \code{\link{get_mob_stats}}. The p-value for each statistic
 is displayed in the plot title if applicable.
 }
-\details{
-The user may specify which results to plot or simply to plot 
-all the results.
-}
-\author{
-Felix May, Xiao Xiao, and Dan McGlinn
+\examples{
+data(tank_comm)
+data(tank_plot_attr)
+tank_mob <- make_mob_in(tank_comm, tank_plot_attr)
+# for quick results we specify a low number of permutations 
+# and bootstrap samples these should be increased in real 
+# analyses. 
+tank_stats <- get_mob_stats(tank_mob, 'group', 'low',
+                            index = c('S', 'S_PIE', 'S_C'),
+                            n_perm = 19, ci_algo = 'boot', ci_n_boot = 20)
+p <- plot(tank_stats, 'group')
+# plot of S
+p$S
+# plot of S_PIE
+p$S_PIE
+# plot of S_C
+p$S_C
 }

--- a/man/plot_comm_div.Rd
+++ b/man/plot_comm_div.Rd
@@ -51,6 +51,8 @@ library(dplyr)
 data(tank_comm)
 data(tank_plot_attr)
 indices <- c('N', 'S', 'S_C', 'S_n', 'S_PIE')
+# the grouping variable must be called group in the 
+# tank_div data.frame
 tank_div <- tibble(tank_comm) |> 
   group_by(group = tank_plot_attr$group) |> 
   group_modify(~ calc_comm_div(.x, index = indices, effort = 5,

--- a/vignettes/mobr_intro.Rmd
+++ b/vignettes/mobr_intro.Rmd
@@ -14,9 +14,8 @@ the source code here [mobr on GitHub](https://github.com/MoBiodiv/mobr)
 The easiest option is to install the package directly from GitHub using the package `devtools`. If you do not already have `devtools` installed then need to install it.
 
 ```{r install package, eval = F}
-install.packages('devtools')
-library(devtools)
-install_github('MoBiodiv/mobr')
+install.packages('remotes')
+remotes::install_github('MoBiodiv/mobr')
 ```
 
 If you receive an error we would love to receive your bug report 
@@ -84,15 +83,31 @@ First let's look at the spatial, sample-based rarefaction (sSBR) in which sample
 added depending on their spatial proximity. 
 
 ```{r, fig.width = 5, fig.height = 5}
-plot_rarefaction(inv_mob_in, 'group', ref_level = 'uninvaded', 'sSBR', lwd = 4)
+plot_rarefaction(inv_mob_in, 'group', ref_level = 'uninvaded', 'sSBR', lwd = 4,
+                 scale = c('gamma', 'study'))
 ```
 
-We can see that invasion decreases richness and that the magnitude of the effect
-depends on scale. Let's dig in further to see if we can better understand
-exactly what components of the community are changing due to invasion.
+In this spatial, sample-based rarefaction curve we are focusing on the gamma
+scale for each group (pink and blue group specific lines) and the study scale
+(black combined group line). The alpha scale is visible on this plot as the 
+average richness when the number of samples equals 1. 
 
-First we look at the individual rarefaction curves for each treatment which
-only reflect the shape of the SAD (i.e., no individual density or aggregation effects):
+We can see that invasion decreases richness and that the magnitude of the effect
+depends on scale. Also notice that the rarefaction curve for both groups combined
+largely overlaps the uninvaded curve whereas the invaded curve falls well below it. 
+This pattern indicates that the invaded sites are largely a nested subset of
+species that are found in the uninvaded group. In other words, there is a difference
+in species composition between the two groups but it is one that is primarily 
+driven by nestedness. 
+
+Let's dig in further to see if we can better understand exactly what components
+of the community are changing due to invasion.
+
+First, we look at the individual rarefaction curves (IBRs) for each treatment
+which only reflect the shape of the SAD (i.e., no individual density or
+aggregation effects). We can examine these curves within each sample (i.e.,
+alpha scale), within a groups (i.e., gamma scale), and between groups (i.e.,
+study scale).
 
 ```{r, fig.width = 7, fig.height=4}
 oldpar <- par(no.readonly = TRUE)       
@@ -101,26 +116,85 @@ plot_rarefaction(inv_mob_in, 'group', 'uninvaded', 'IBR',
                  leg_loc = 'bottomright')
 par(oldpar)
 ```
+On plots of an IBR the x-axis (number of samples) now indicates the number of
+individuals sampled (not the number of quadrats as in the sSBR). Note that the
+panel on the left is visually truncated to show only the range of individuals
+that both treatments have in common. You can see in the panel on the right that
+the uninvaded sites has many more individuals than the invaded sites (pink curve
+is a lot longer than blue curve).
 
-Visually you can see there are some big differences in total numbers individuals
-(i.e., how far on the x-axis the curves go). We can also see that for small 
-numbers of individuals the invaded sites are actually more diverse! This is 
-a bit surprising and it implies that the invaded sites have greater evenness. 
-We can directly examine the species abundance distribution (SAD):
+Above in the panel on the left ("Within Groups") we see small transparent curves
+these are computed for each sample (quadrats in this case), and a thicker solid
+line of the same color these are computed by pooling across all the samples in
+the same group. 
 
+The solid lines in the "Within Groups" panel are the same colored lines on the 
+"Between Groups" panel just now displayed across the full range of number of
+individuals. 
+
+We can learn a lot from these plots if we know how to read them. First, it is
+clear that the invaded site actually appear to be more diverse for a given
+number of individuals! This is surprising because it is the opposite of what
+we observed in the sSBR. That indicates that when we ignore spatial aggregation
+and differences in total abundance the invaded site appears to be more diverse
+- in other words it likely has higher evenness. 
+
+The panel on the right indicates like the sSBR that the univaded site has more
+species overall (at the gamma scale). **Is this overall difference in diversity
+primarily driven by the fact that the invaded sites have so many fewer
+individuals?** We can come back to this question later in the analysis. We can
+further examine for differences in evenness by also examining plots of the
+species abundance distribution (SAD) - see below.
+
+We can also learn about beta-diversity from these plots both within and between
+groups. The closer the sample specific and group specific curves are the lower
+the beta diversity because that indicates that all the samples have pretty much
+the same species - pooling them together should result in a faster rate of
+species gain if each sample has different species composition.
+
+It is not super clear from the graphics if beta-diversity is higher in the 
+invaded or the uninvaded site. At the study scale as indicated by the sSBR it
+does appear that the invaded and uninvaded sites have different species
+composition but this is 
+
+Ok let's examine those SADs now to look for visual differences in evenness. 
+```{r, fig.width = 7, fig.height=4}
+oldpar <- par(no.readonly = TRUE)
+par(mfrow = c(1, 2))
+plot_abu(inv_mob_in, 'group', type = 'sad', scale = 'alpha',
+         leg_loc = NA)
+plot_abu(inv_mob_in, 'group', type = 'sad', scale = 'gamma' ,
+         leg_loc = 'bottomright')
+par(oldpar)
+```
+In these SAD plots communities lines that are more linear indicate that 
+with each added species you see a similar increase in abundance (high evenness)
+while concave down plots indicate that a common species dominate most of the 
+abundance (low evenness ).
+
+The SADs suggest that the invaded site does have greater evenness (the curves are
+closer to a linear pattern particularly at the alpha scale) as expected
+from the IBR rarefaction curve comparison. 
+
+We can also inspect these curves as ranked-abundance curves if those are preferred: 
 
 ```{r, fig.width = 7, fig.height=4}
 oldpar <- par(no.readonly = TRUE)
 par(mfrow = c(1, 2))
-plot_abu(inv_mob_in, 'group', type = 'rad', scale = 'alpha', log = 'x')
+plot_abu(inv_mob_in, 'group', type = 'rad', scale = 'alpha', log = 'x',
+         leg_loc = NA)
 plot_abu(inv_mob_in, 'group', type = 'rad', scale = 'gamma' , log = 'x')
 par(oldpar)
 ```
+In these ranked plots the flatter the curve the higher then evenness. 
+These again are indicating that uninvaded sites have most of their abundance
+tied up in a few species (i.e., low evenness). 
 
-The SADs suggest that the invaded site has greater evenness in its common
-species (i.e., flatter left hand-side of rank curve).
+Now that we have visually examined the community patterns let's calculate some
+key biodiversity statistics and compare them with permutation tests and
+bootstrapped confidence intervals.
 
-# Two-scale analysis
+# MoB Multi-metric Analysis
 
 There are a myriad of biodiversity indices. We have attempted to chose a subset
 of metrics that can all be derived from the individual rarefaction curve which
@@ -155,7 +229,7 @@ which makes that calculation difficult for this example (see below for examples
 in which *S_C* is computed).
 
 ```{r compute diversity indices, eval = TRUE}
-indices <- c('N', 'S', 'S_n', 'S_PIE')
+indices <- c('N', 'S', 'S_n', 'S_C', 'S_PIE')
 inv_div <- tibble(inv_comm) %>% 
   group_by(group = inv_plot_attr$group) %>% 
   group_modify(~ calc_comm_div(.x, index = indices, effort = 5,


### PR DESCRIPTION
Overall a minor update that does fix one bug in `get_mob_stats`. The previous version was not using a common target coverage across all groups. This is fixed here. The old `plot.mob_stats` function has been brought back. It's job is plot the output from `get_mob_stats`. I have begun updating the vignette but it still needs more work. No change in version on this update. 