### PR TITLE
docs(README): use pak::pkg_install instead of devtools::install_github

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .RData
 .Ruserdata
 inst/doc
+mobr.Rproj

--- a/README.md
+++ b/README.md
@@ -37,17 +37,11 @@ citation(package = "mobr")
 install.packages('mobr')
 ```
 
-Or, install development version
+Or, install the development version from GitHub:
 
 ```r
-install.packages('devtools')
-library(devtools)
-```
-
-Now that `devtools` is installed you can install `mobr using the following R code:
-
-```r
-install_github('MoBiodiv/mobr')
+# install.packages("pak")
+pak::pkg_install("MoBiodiv/mobr")
 ```
 
 ## Examples


### PR DESCRIPTION
## Summary
- Replace the `install.packages('devtools') + library(devtools) + install_github('MoBiodiv/mobr')` block with a single `pak::pkg_install("MoBiodiv/mobr")`. `pak` is now the recommended installer.

## Test plan
- [x] README.md edited locally